### PR TITLE
doc: add quotes to jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Following please find a few apis to help you getting started quickly
 
   2. Create a new api
     ```
-    $ curl -s  -H "x-tyk-authorization: foo" http://localhost:8080/tyk/apis/ -d @my-api -X POST | jq .
+    $ curl -s  -H "x-tyk-authorization: foo" http://localhost:8080/tyk/apis/ -d @my-api -X POST | jq '.
     {
       "key": "2",
       "status": "ok",
       "action": "added"
-    }
+    }'
     ```
 
   3. If you check the list of APIs again ,you'll see no change. You need to hot reload the gateway so it'll start listening to the new api


### PR DESCRIPTION
fix wrong command in documentation by adding quotes to jq